### PR TITLE
feature: support ZodCustom and ZodEffect (refine/transfrom/...)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,7 @@
   },
   "imports": {
     "zod": "npm:zod@^3.22.4",
+    "ts_brand": "https://deno.land/x/ts_brand@0.0.1/mod.ts",
     "hono": "npm:hono@^4.1.0",
     "assert": "jsr:@std/assert@^0.219.0/assert"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -2,14 +2,26 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@std/assert": "jsr:@std/assert@0.219.1",
       "jsr:@std/assert@^0.219.0": "jsr:@std/assert@0.219.1",
+      "jsr:@std/fmt@^0.219.1": "jsr:@std/fmt@0.219.1",
+      "jsr:@std/testing": "jsr:@std/testing@1.0.3",
       "npm:hono@^4.1.0": "npm:hono@4.1.0",
       "npm:superjson@1.13.3": "npm:superjson@1.13.3",
       "npm:zod@^3.22.4": "npm:zod@3.22.4"
     },
     "jsr": {
       "@std/assert@0.219.1": {
-        "integrity": "e76c2a1799a78f0f4db7de04bdc9b908a7a4b821bb65eda0285885297d4fb8af"
+        "integrity": "e76c2a1799a78f0f4db7de04bdc9b908a7a4b821bb65eda0285885297d4fb8af",
+        "dependencies": [
+          "jsr:@std/fmt@^0.219.1"
+        ]
+      },
+      "@std/fmt@0.219.1": {
+        "integrity": "2432152e927df249a207177aa048a6d9465956ea0047653ee6abd4f514db504f"
+      },
+      "@std/testing@1.0.3": {
+        "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42"
       }
     },
     "npm": {
@@ -41,7 +53,9 @@
   },
   "remote": {
     "https://deno.land/std@0.203.0/dotenv/load.ts": "0636983549b98f29ab75c9a22a42d9723f0a389ece5498fe971e7bb2556a12e2",
-    "https://deno.land/std@0.203.0/dotenv/mod.ts": "1da8c6d0e7f7d8a5c2b19400b763bc11739df24acec235dda7ea2cfd3d300057"
+    "https://deno.land/std@0.203.0/dotenv/mod.ts": "1da8c6d0e7f7d8a5c2b19400b763bc11739df24acec235dda7ea2cfd3d300057",
+    "https://deno.land/x/ts_brand@0.0.1/mod.ts": "0c76b065874f3f81fd44f8058954144268ed25ced55bd7b57d964bc724d29274",
+    "https://deno.land/x/ts_brand@0.0.1/src/mod.ts": "d343ce7bda5d3d080f12bdd2534f4550bf1bb0ed00a98030d1fbc6eddba9c426"
   },
   "workspace": {
     "dependencies": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ZodBoolean,
   ZodDate,
   ZodDefault,
+  ZodEffects,
   ZodEnum,
   ZodLiteral,
   ZodNullable,
@@ -14,6 +15,7 @@ import type {
   ZodRawShape,
   ZodString,
   ZodType,
+  ZodTypeDef,
   ZodUnion,
 } from "zod"
 
@@ -272,6 +274,18 @@ export type PrimitiveParamProperty =
   | ZodEnum<[string, ...string[]]>
   | ZodLiteral<number | string | boolean | bigint>
 
+type EffectParamProperty = ZodEffects<
+  PrimitiveParamProperty,
+  unknown,
+  number | string | boolean | bigint
+>
+
+type ZodTypeParamProperty = ZodType<
+  unknown,
+  ZodTypeDef,
+  unknown
+>
+
 export type ParamProperty =
   | PrimitiveParamProperty
   | ZodUnion<[ParamProperty, ...ParamProperty[]]>
@@ -283,6 +297,8 @@ export type ParamsSchema<T extends string = string> = ZodObject<
       | ParamProperty
       | ZodOptional<ParamProperty>
       | ZodNullable<ParamProperty>
+      | EffectParamProperty
+      | ZodTypeParamProperty
   }
 >
 

--- a/tests/server/effects.type.test.ts
+++ b/tests/server/effects.type.test.ts
@@ -1,0 +1,286 @@
+import { z } from "zod"
+import { type Brand, make } from "https://deno.land/x/ts_brand@0.0.1/mod.ts"
+import { client } from "../../src/client.ts"
+import { resource } from "../../src/resource.ts"
+import { assertType, type IsExact } from "jsr:@std/testing/types"
+
+// This example bases on usecase that I couldn't use custom+transforms in
+// In real-world scenario there's another layer that adds `Bearer ...` and brands it as a header value, I've skipped it here
+// Current version doesn't offer typeguards for transform (not sure how to approach it), custom is handled automagically
+// It allows you to use your current typeguarded schemas without typeerrors
+
+type UserToken = Brand<string, "UserToken">
+const makeUserToken = (userToken: string) => make<UserToken>()(userToken)
+const userTokenSchema = z.string().transform(makeUserToken)
+const userAuthHeaderSchema = z.object({
+  Authorization: userTokenSchema,
+})
+const userTokenSchema2 = z
+  .custom<UserToken>((x) => typeof x === "string")
+  .transform(makeUserToken)
+const userAuthHeaderSchema_USING_CUSTOM = z.object({
+  Authorization: userTokenSchema2,
+})
+
+type AppToken = Brand<string, "AppToken">
+const makeAppToken = (appToken: string) => make<AppToken>()(appToken)
+const appTokenSchema = z.string().transform(makeAppToken)
+const appAuthHeaderSchema = z.object({
+  Authorization: appTokenSchema,
+})
+
+// Let's pretend this API just takes Authorization as every option and responds with Authorization
+const api = client({
+  fetcher: () => Promise.resolve(new Response("mock")),
+  baseUrl: "test",
+  resources: {
+    endpointForUsers: resource("/user/header/echo", {
+      actions: {
+        get: {
+          dataSchema: userAuthHeaderSchema,
+          headersSchema: userAuthHeaderSchema,
+          searchParamsSchema: userAuthHeaderSchema,
+        },
+        post: {
+          dataSchema: userAuthHeaderSchema,
+          headersSchema: userAuthHeaderSchema,
+          bodySchema: userAuthHeaderSchema,
+          searchParamsSchema: userAuthHeaderSchema,
+        },
+        delete: {
+          bodySchema: userAuthHeaderSchema_USING_CUSTOM,
+          dataSchema: userAuthHeaderSchema_USING_CUSTOM,
+          headersSchema: userAuthHeaderSchema_USING_CUSTOM,
+          searchParamsSchema: userAuthHeaderSchema_USING_CUSTOM,
+        },
+        options: {
+          bodySchema: userAuthHeaderSchema,
+          dataSchema: userAuthHeaderSchema,
+          headersSchema: userAuthHeaderSchema,
+          searchParamsSchema: userAuthHeaderSchema,
+        },
+        patch: {
+          bodySchema: userAuthHeaderSchema,
+          dataSchema: userAuthHeaderSchema,
+          headersSchema: userAuthHeaderSchema,
+          searchParamsSchema: userAuthHeaderSchema,
+        },
+        put: {
+          bodySchema: userAuthHeaderSchema,
+          dataSchema: userAuthHeaderSchema,
+          headersSchema: userAuthHeaderSchema,
+          searchParamsSchema: userAuthHeaderSchema,
+        },
+      },
+    }),
+    endpointForApp: resource("/app/header/echo", {
+      actions: {
+        get: {
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+        post: {
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          bodySchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+        delete: {
+          bodySchema: appAuthHeaderSchema,
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+        options: {
+          bodySchema: appAuthHeaderSchema,
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+        patch: {
+          bodySchema: appAuthHeaderSchema,
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+        put: {
+          bodySchema: appAuthHeaderSchema,
+          dataSchema: appAuthHeaderSchema,
+          headersSchema: appAuthHeaderSchema,
+          searchParamsSchema: appAuthHeaderSchema,
+        },
+      },
+    }),
+  },
+})
+
+const appToken = makeAppToken("appToken")
+const userToken = makeUserToken("userToken")
+
+Deno.test("Call with branding types", async () => {
+  const a = await api.endpointForUsers.delete({
+    body: { Authorization: userToken },
+    headers: { Authorization: userToken },
+    searchParams: { Authorization: userToken },
+  })
+
+  assertType<
+    IsExact<
+      typeof a.data,
+      {
+        Authorization: UserToken
+      } | null
+    >
+  >(true)
+})
+
+Deno.test("Expect type error when using incorrect branded type", () => {
+  // dryrun, test will fail to build if it ever doesn't produce an error
+  api.endpointForUsers.delete({
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    body: { Authorization: appToken },
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    headers: { Authorization: appToken },
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    searchParams: { Authorization: appToken },
+  })
+})
+
+Deno.test("Expect type error when not using brands when brands are required", () => {
+  // dryrun, test will fail to build if it ever doesn't produce an error
+  api.endpointForUsers.delete({
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    body: { Authorization: "Bearer something" },
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    headers: { Authorization: "Bearer something" },
+    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    searchParams: { Authorization: "Bearer something" },
+  })
+})
+
+Deno.test("Typecheck custom", () => {
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.delete
+      >[0]["body"]["Authorization"],
+      UserToken
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.delete
+      >[0]["headers"]["Authorization"],
+      UserToken
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.delete
+      >[0]["searchParams"]["Authorization"],
+      UserToken
+    >
+  >(true)
+})
+
+Deno.test("Typecheck transfrom", () => {
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.options
+      >[0]["body"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.options
+      >[0]["headers"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.options
+      >[0]["searchParams"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.patch
+      >[0]["body"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.patch
+      >[0]["headers"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.patch
+      >[0]["searchParams"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.post
+      >[0]["body"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.post
+      >[0]["headers"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.post
+      >[0]["searchParams"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.put
+      >[0]["body"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.put
+      >[0]["headers"]["Authorization"],
+      string
+    >
+  >(true)
+  assertType<
+    IsExact<
+      Parameters<
+        typeof api.endpointForUsers.put
+      >[0]["searchParams"]["Authorization"],
+      string
+    >
+  >(true)
+})

--- a/tests/server/effects.type.test.ts
+++ b/tests/server/effects.type.test.ts
@@ -150,11 +150,11 @@ Deno.test("Expect type error when using incorrect branded type", () => {
 Deno.test("Expect type error when not using brands when brands are required", () => {
   // dryrun, test will fail to build if it ever doesn't produce an error
   api.endpointForUsers.delete({
-    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    // @ts-expect-error this should be userToken, string should be catched by typeguard
     body: { Authorization: "Bearer something" },
-    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    // @ts-expect-error this should be userToken, string should be catched by typeguard
     headers: { Authorization: "Bearer something" },
-    // @ts-expect-error this should be userToken, appToken should be catched by typeguard
+    // @ts-expect-error this should be userToken, string should be catched by typeguard
     searchParams: { Authorization: "Bearer something" },
   })
 })


### PR DESCRIPTION
I like to brand types like api keys or access tokens in projects that integrate many APIs or with APIs that have multiple tiers of access based on eachother.
So for example I get typeguard firing a red underline under a call to user-protected endpoint with bot account access token instead of figuring what went wrong during runtime.